### PR TITLE
Add Path= qualifier to bindings.

### DIFF
--- a/MultiSelectTreeView/Themes/MultiSelectTreeViewItem.Aero.xaml
+++ b/MultiSelectTreeView/Themes/MultiSelectTreeViewItem.Aero.xaml
@@ -94,11 +94,11 @@
 
 		<!-- Pass on the MultiSelectTreeView' HoverHighlighting value to each item because we couldn't access it otherwise in the triggers -->
 		<Setter Property="HoverHighlighting"
-			Value="{Binding (Controls:MultiSelectTreeView.HoverHighlighting), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.HoverHighlighting), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 		<Setter Property="ItemIndent"
-			Value="{Binding (Controls:MultiSelectTreeView.ItemIndent), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.ItemIndent), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 		<Setter Property="IsKeyboardMode"
-			Value="{Binding (Controls:MultiSelectTreeView.IsKeyboardMode), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.IsKeyboardMode), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 
 		<Setter Property="Control.Template">
 			<Setter.Value>

--- a/MultiSelectTreeView/Themes/MultiSelectTreeViewItem.Aero2.xaml
+++ b/MultiSelectTreeView/Themes/MultiSelectTreeViewItem.Aero2.xaml
@@ -66,11 +66,11 @@
 
 		<!-- Pass on the MultiSelectTreeView' HoverHighlighting value to each item because we couldn't access it otherwise in the triggers -->
 		<Setter Property="HoverHighlighting"
-			Value="{Binding (Controls:MultiSelectTreeView.HoverHighlighting), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.HoverHighlighting), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 		<Setter Property="ItemIndent"
-			Value="{Binding (Controls:MultiSelectTreeView.ItemIndent), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.ItemIndent), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 		<Setter Property="IsKeyboardMode"
-			Value="{Binding (Controls:MultiSelectTreeView.IsKeyboardMode), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.IsKeyboardMode), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 
 		<Setter Property="Control.Template">
 			<Setter.Value>

--- a/MultiSelectTreeView/Themes/MultiSelectTreeViewItem.Classic.xaml
+++ b/MultiSelectTreeView/Themes/MultiSelectTreeViewItem.Classic.xaml
@@ -78,11 +78,11 @@
 
 		<!-- Pass on the MultiSelectTreeView' HoverHighlighting value to each item because we couldn't access it otherwise in the triggers -->
 		<Setter Property="HoverHighlighting"
-			Value="{Binding (Controls:MultiSelectTreeView.HoverHighlighting), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.HoverHighlighting), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 		<Setter Property="ItemIndent"
-			Value="{Binding (Controls:MultiSelectTreeView.ItemIndent), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.ItemIndent), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 		<Setter Property="IsKeyboardMode"
-			Value="{Binding (Controls:MultiSelectTreeView.IsKeyboardMode), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.IsKeyboardMode), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 
 		<Setter Property="Control.Template">
 			<Setter.Value>

--- a/MultiSelectTreeView/Themes/MultiSelectTreeViewItem.Luna.xaml
+++ b/MultiSelectTreeView/Themes/MultiSelectTreeViewItem.Luna.xaml
@@ -58,11 +58,11 @@
 
 		<!-- Pass on the MultiSelectTreeView' HoverHighlighting value to each item because we couldn't access it otherwise in the triggers -->
 		<Setter Property="HoverHighlighting"
-			Value="{Binding (Controls:MultiSelectTreeView.HoverHighlighting), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.HoverHighlighting), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 		<Setter Property="ItemIndent"
-			Value="{Binding (Controls:MultiSelectTreeView.ItemIndent), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.ItemIndent), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 		<Setter Property="IsKeyboardMode"
-			Value="{Binding (Controls:MultiSelectTreeView.IsKeyboardMode), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
+			Value="{Binding Path=(Controls:MultiSelectTreeView.IsKeyboardMode), RelativeSource={RelativeSource AncestorType={x:Type Controls:MultiSelectTreeView}}, Mode=OneWay}"/>
 
 		<Setter Property="Control.Template">
 			<Setter.Value>


### PR DESCRIPTION
When a binding contains parenthesis then the Path= syntax must be used.
Fixes #17 