### PR TITLE
Fix null pointer error in MultiSelectTreeView.cs

### DIFF
--- a/MultiSelectTreeView/Controls/MultiSelectTreeView.cs
+++ b/MultiSelectTreeView/Controls/MultiSelectTreeView.cs
@@ -496,7 +496,7 @@ namespace System.Windows.Controls
 				case NotifyCollectionChangedAction.Reset:
 					// If the items list has considerably changed, the selection is probably
 					// useless anyway, clear it entirely.
-					SelectedItems.Clear();
+					SelectedItems?.Clear();
 					break;
 			}
 			


### PR DESCRIPTION
When databinding, I found `SelectedItems` was being referenced before it was instantiated; this avoids the only error I was having with that.