### PR TITLE
Avoid consuming F2 when name editing is disabled

### DIFF
--- a/MultiSelectTreeView/Controls/MultiSelectTreeViewItem.cs
+++ b/MultiSelectTreeView/Controls/MultiSelectTreeViewItem.cs
@@ -592,9 +592,9 @@ namespace System.Windows.Controls
 						if (ParentTreeView.AllowEditItems && ContentTemplateEdit != null && IsFocused && IsEditable)
 						{
 							IsEditing = true;
-                            e.Handled = true;
-                        }
-                        break;
+							e.Handled = true;
+						}
+						break;
 					case Key.Escape:
 						StopEditing();
 						e.Handled = true;

--- a/MultiSelectTreeView/Controls/MultiSelectTreeViewItem.cs
+++ b/MultiSelectTreeView/Controls/MultiSelectTreeViewItem.cs
@@ -592,9 +592,9 @@ namespace System.Windows.Controls
 						if (ParentTreeView.AllowEditItems && ContentTemplateEdit != null && IsFocused && IsEditable)
 						{
 							IsEditing = true;
-						}
-						e.Handled = true;
-						break;
+                            e.Handled = true;
+                        }
+                        break;
 					case Key.Escape:
 						StopEditing();
 						e.Handled = true;


### PR DESCRIPTION
In the MultiSelectTreeViewItem.OnKeyDown, do not set e.Handled while processing F2 unless the editing is possible. This allows users to add their own key binding for F2 in inputbindings on the control. Currently one can have AllowEditItems = false but the item still "eats" the key down.

I hope this makes sense.